### PR TITLE
support utf-8

### DIFF
--- a/XSourceNote/XSourceNote.m
+++ b/XSourceNote/XSourceNote.m
@@ -120,7 +120,7 @@
 //    NSLog(@"code below = \n%@", codeOfLines);
     
     // length of "file://" is 7
-    NSString *sourcePath = [[editor.sourceCodeDocument.fileURL absoluteString] substringFromIndex:7];
+    NSString *sourcePath = [[[editor.sourceCodeDocument.fileURL absoluteString] substringFromIndex:7] stringByRemovingPercentEncoding];
     
     XSourceNoteStorage *st = [XSourceNoteStorage sharedStorage];
     if([st.rootPath isEqualToString:@""]){

--- a/XSourceNote/XSourceNoteUtil.m
+++ b/XSourceNote/XSourceNoteUtil.m
@@ -90,7 +90,7 @@
     if(nil == document)
         return nil;
     DVTFilePath *workspacefilePath = document.workspace.representingFilePath;
-    return [workspacefilePath.fileURL absoluteString];
+    return [[workspacefilePath.fileURL absoluteString] stringByRemovingPercentEncoding];
 }
 
 + (void)highlightLine:(NSUInteger)lineNumber inTextView:(NSTextView*)textView


### PR DESCRIPTION
修正當專案名或檔案名非ascii時，某些功能不正常。
如： 秀不出Green Tag 和 點擊Edit notes自動跳到該檔案等
